### PR TITLE
Escape the paths for the `github-changes` bin file

### DIFF
--- a/tasks/github_changes.js
+++ b/tasks/github_changes.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
 
         return [
             process.execPath,
-            ghC,
+            JSON.stringify(ghC),
             owner,
             repository,
             branch,


### PR DESCRIPTION
Poor-mans escaping, it might be needed for more properties/arguments.
